### PR TITLE
[feat] 개인정보 수정 로직 구현 (#10)

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -31,6 +31,17 @@ async function bootstrap() {
     .setTitle('Ddareuni-Map API documents')
     .setDescription('따릉이맵 API 문서입니다.')
     .setVersion('1.0')
+    .addBearerAuth(
+      {
+        type: 'http',
+        scheme: 'bearer',
+        bearerFormat: 'JWT',
+        name: 'JWT',
+        description: 'Enter JWT token',
+        in: 'header',
+      },
+      'JWT-auth', // This name here is important for matching up with @ApiBearerAuth() in your controller!
+    )
     .addOAuth2({
       type: 'oauth2',
       flows: {

--- a/src/user/dto/change-password.dto.ts
+++ b/src/user/dto/change-password.dto.ts
@@ -1,0 +1,22 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsString, MinLength, MaxLength } from 'class-validator';
+
+export class ChangePasswordDto {
+  @ApiProperty({
+    description: '현재 비밀번호',
+    example: 'currentPassword123!'
+  })
+  @IsNotEmpty({ message: '현재 비밀번호는 필수입니다.' })
+  @IsString({ message: '현재 비밀번호는 문자열이어야 합니다.' })
+  currentPassword: string;
+
+  @ApiProperty({
+    description: '새로운 비밀번호 (8-255자)',
+    example: 'newPassword456!'
+  })
+  @IsNotEmpty({ message: '새로운 비밀번호는 필수입니다.' })
+  @IsString({ message: '새로운 비밀번호는 문자열이어야 합니다.' })
+  @MinLength(8, { message: '새로운 비밀번호는 최소 8글자 이상이어야 합니다.' })
+  @MaxLength(255, { message: '새로운 비밀번호는 최대 255글자 이하여야 합니다.' })
+  newPassword: string;
+}

--- a/src/user/dto/update-user-info.dto.ts
+++ b/src/user/dto/update-user-info.dto.ts
@@ -1,0 +1,39 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsString, IsOptional, IsIn, Matches } from 'class-validator';
+
+export class UpdateUserInfoDto {
+  @ApiProperty({
+    description: '사용자 이름',
+    example: '홍길동'
+  })
+  @IsNotEmpty({ message: '이름은 필수입니다.' })
+  @IsString({ message: '이름은 문자열이어야 합니다.' })
+  name: string;
+
+  @ApiProperty({
+    description: '생년월일 (YYYY-MM-DD 형식)',
+    example: '1990-01-01'
+  })
+  @IsNotEmpty({ message: '생년월일은 필수입니다.' })
+  @IsString({ message: '생년월일은 문자열이어야 합니다.' })
+  birthDate: string;
+
+  @ApiProperty({
+    description: '성별 (M: 남성, F: 여성)',
+    example: 'M',
+    enum: ['M', 'F']
+  })
+  @IsNotEmpty({ message: '성별은 필수입니다.' })
+  @IsString({ message: '성별은 문자열이어야 합니다.' })
+  @IsIn(['M', 'F'], { message: '성별은 M(남성) 또는 F(여성)이어야 합니다.' })
+  gender: string;
+
+  @ApiProperty({
+    description: '주소',
+    example: '서울특별시-강남구-역삼동',
+    required: false
+  })
+  @IsOptional()
+  @IsString({ message: '주소는 문자열이어야 합니다.' })
+  address?: string;
+}

--- a/src/user/dto/user-info-response.dto.ts
+++ b/src/user/dto/user-info-response.dto.ts
@@ -1,0 +1,28 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class UserInfoResponseDto {
+  @ApiProperty({
+    description: '사용자 이름',
+    example: '홍길동'
+  })
+  name: string;
+
+  @ApiProperty({
+    description: '생년월일',
+    example: '1990-01-01'
+  })
+  birthDate: string;
+
+  @ApiProperty({
+    description: '성별 (M: 남성, F: 여성)',
+    example: 'M'
+  })
+  gender: string;
+
+  @ApiProperty({
+    description: '주소',
+    example: '서울특별시 강남구',
+    nullable: true
+  })
+  address: string | null;
+}

--- a/src/user/guards/jwt-auth.guard.ts
+++ b/src/user/guards/jwt-auth.guard.ts
@@ -1,0 +1,35 @@
+import { Injectable, ExecutionContext, UnauthorizedException } from '@nestjs/common';
+import { AuthGuard } from '@nestjs/passport';
+import { JwtService } from '@nestjs/jwt';
+
+@Injectable()
+export class JwtAuthGuard extends AuthGuard('jwt') {
+  constructor(private jwtService: JwtService) {
+    super();
+  }
+
+  canActivate(context: ExecutionContext) {
+    const request = context.switchToHttp().getRequest();
+    const authHeader = request.headers.authorization;
+
+    if (!authHeader) {
+      throw new UnauthorizedException({
+        statusCode: 401,
+        message: '토큰이 제공되지 않았습니다.',
+      });
+    }
+
+    const token = authHeader.replace('Bearer ', '');
+    
+    try {
+      const decoded = this.jwtService.verify(token);
+      request.user = decoded;
+      return true;
+    } catch (error) {
+      throw new UnauthorizedException({
+        statusCode: 401,
+        message: '유효하지 않은 토큰입니다.',
+      });
+    }
+  }
+}

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -1,10 +1,14 @@
-import { Controller, Post, Body, HttpCode, HttpStatus, BadRequestException } from '@nestjs/common';
-import { ApiTags, ApiOperation, ApiResponse, ApiBody } from '@nestjs/swagger';
+import { Controller, Post, Get, Put, Body, Request, HttpCode, HttpStatus, BadRequestException, UseGuards } from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiResponse, ApiBody, ApiBearerAuth } from '@nestjs/swagger';
 import { UserService } from './user.service';
 import { 
   CreateUserDto
 } from './dto/create-user.dto';
 import { LoginUserDto } from './dto/login-user.dto';
+import { UserInfoResponseDto } from './dto/user-info-response.dto';
+import { UpdateUserInfoDto } from './dto/update-user-info.dto';
+import { ChangePasswordDto } from './dto/change-password.dto';
+import { JwtAuthGuard } from './guards/jwt-auth.guard';
 
 @ApiTags('유저 (User)')
 @Controller('user')
@@ -73,5 +77,152 @@ export class UserController {
     return await this.userService.login(loginUserDto);
   }
 
-  
+  @Get('info')
+  @UseGuards(JwtAuthGuard)
+  @HttpCode(HttpStatus.OK)
+  @ApiBearerAuth('JWT-auth')
+  @ApiOperation({ 
+    summary: '내 정보 조회',
+    description: 'JWT 토큰을 통해 현재 로그인한 사용자의 정보를 조회합니다.'
+  })
+  @ApiResponse({ 
+    status: 200, 
+    description: '사용자 정보 조회 성공',
+    type: UserInfoResponseDto
+  })
+  @ApiResponse({ 
+    status: 401, 
+    description: '인증되지 않은 사용자 (토큰 없음 또는 유효하지 않은 토큰)',
+    schema: {
+      example: {
+        statusCode: 401,
+        message: '유효하지 않은 토큰입니다.',
+        error: 'Unauthorized'
+      }
+    }
+  })
+  @ApiResponse({ 
+    status: 404, 
+    description: '사용자를 찾을 수 없음',
+    schema: {
+      example: {
+        statusCode: 404,
+        message: '사용자를 찾을 수 없습니다.',
+        error: 'Not Found'
+      }
+    }
+  })
+  async getUserInfo(@Request() req): Promise<UserInfoResponseDto> {
+    const userId = req.user.userId;
+    return await this.userService.getUserInfo(userId);
+  }
+
+  @Put('info-update')
+  @UseGuards(JwtAuthGuard)
+  @HttpCode(HttpStatus.OK)
+  @ApiBearerAuth('JWT-auth')
+  @ApiOperation({ 
+    summary: '내 정보 수정',
+    description: 'JWT 토큰을 통해 현재 로그인한 사용자의 정보를 수정합니다.'
+  })
+  @ApiBody({ type: UpdateUserInfoDto })
+  @ApiResponse({ 
+    status: 200, 
+    description: '사용자 정보 수정 성공',
+    type: UserInfoResponseDto
+  })
+  @ApiResponse({ 
+    status: 400, 
+    description: '잘못된 요청 (유효성 검사 실패, 올바르지 않은 생년월일 형식 등)',
+    schema: {
+      example: {
+        statusCode: 400,
+        message: '올바르지 않은 생년월일 형식입니다.',
+        error: 'Bad Request'
+      }
+    }
+  })
+  @ApiResponse({ 
+    status: 401, 
+    description: '인증되지 않은 사용자 (토큰 없음 또는 유효하지 않은 토큰)',
+    schema: {
+      example: {
+        statusCode: 401,
+        message: '유효하지 않은 토큰입니다.',
+        error: 'Unauthorized'
+      }
+    }
+  })
+  @ApiResponse({ 
+    status: 404, 
+    description: '사용자를 찾을 수 없음',
+    schema: {
+      example: {
+        statusCode: 404,
+        message: '사용자를 찾을 수 없습니다.',
+        error: 'Not Found'
+      }
+    }
+  })
+  async updateUserInfo(@Request() req, @Body() updateUserInfoDto: UpdateUserInfoDto): Promise<UserInfoResponseDto> {
+    const userId = req.user.userId;
+    return await this.userService.updateUserInfo(userId, updateUserInfoDto);
+  }
+
+  @Put('password')
+  @UseGuards(JwtAuthGuard)
+  @HttpCode(HttpStatus.OK)
+  @ApiBearerAuth('JWT-auth')
+  @ApiOperation({ 
+    summary: '비밀번호 변경',
+    description: 'JWT 토큰을 통해 현재 로그인한 사용자의 비밀번호를 변경합니다.'
+  })
+  @ApiBody({ type: ChangePasswordDto })
+  @ApiResponse({ 
+    status: 200, 
+    description: '비밀번호 변경 성공',
+    schema: {
+      example: {
+        message: '비밀번호가 성공적으로 변경되었습니다.'
+      }
+    }
+  })
+  @ApiResponse({ 
+    status: 400, 
+    description: '잘못된 요청 (같은 비밀번호, 유효성 검사 실패 등)',
+    schema: {
+      example: {
+        statusCode: 400,
+        message: '같은 비밀번호입니다. 다른 비밀번호를 입력해주세요.',
+        error: 'Bad Request'
+      }
+    }
+  })
+  @ApiResponse({ 
+    status: 401, 
+    description: '인증되지 않은 사용자 (토큰 없음, 유효하지 않은 토큰, 현재 비밀번호 불일치)',
+    schema: {
+      example: {
+        statusCode: 401,
+        message: '현재 비밀번호가 올바르지 않습니다.',
+        error: 'Unauthorized'
+      }
+    }
+  })
+  @ApiResponse({ 
+    status: 404, 
+    description: '사용자를 찾을 수 없음',
+    schema: {
+      example: {
+        statusCode: 404,
+        message: '사용자를 찾을 수 없습니다.',
+        error: 'Not Found'
+      }
+    }
+  })
+  async changePassword(@Request() req, @Body() changePasswordDto: ChangePasswordDto): Promise<{ message: string }> {
+    const userId = req.user.userId;
+    return await this.userService.changePassword(userId, changePasswordDto);
+  }
+
 }

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -1,9 +1,12 @@
-import { HttpException, Injectable, UnauthorizedException } from '@nestjs/common';
+import { HttpException, Injectable, UnauthorizedException, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { User } from './entities/user.entity';
 import { CreateUserDto } from './dto/create-user.dto';
 import { LoginUserDto } from './dto/login-user.dto';
+import { UserInfoResponseDto } from './dto/user-info-response.dto';
+import { UpdateUserInfoDto } from './dto/update-user-info.dto';
+import { ChangePasswordDto } from './dto/change-password.dto';
 import * as bcrypt from 'bcrypt';
 import { JwtService } from '@nestjs/jwt';
 
@@ -98,6 +101,154 @@ export class UserService {
     await this.userRepository.save(user);
 
     return { accessToken };
+  }
+
+  /**
+   * 토큰을 통해 사용자 정보 조회
+   */
+  async getUserInfo(userId: number): Promise<UserInfoResponseDto> {
+    const user = await this.userRepository.findOne({
+      where: { userId },
+      select: ['name', 'birthDate', 'gender', 'address']
+    });
+
+    if (!user) {
+      throw new NotFoundException({
+        statusCode: 404,
+        message: '사용자를 찾을 수 없습니다.',
+      });
+    }
+
+    // 디버깅: birthDate의 타입과 값 확인
+    console.log('birthDate value:', user.birthDate);
+    console.log('birthDate type:', typeof user.birthDate);
+    console.log('birthDate instanceof Date:', user.birthDate instanceof Date);
+
+    // birthDate를 안전하게 문자열로 변환
+    let formattedBirthDate: string;
+    
+    if (!user.birthDate) {
+      formattedBirthDate = '1970-01-01';
+    } else if (user.birthDate instanceof Date) {
+      formattedBirthDate = user.birthDate.toISOString().split('T')[0];
+    } else if (typeof user.birthDate === 'string') {
+      // PostgreSQL date 타입은 문자열로 반환될 수 있음 (예: '1990-01-01')
+      const birthDateStr = user.birthDate as string;
+      if (birthDateStr.match(/^\d{4}-\d{2}-\d{2}$/)) {
+        // 이미 YYYY-MM-DD 형식인 경우
+        formattedBirthDate = birthDateStr;
+      } else {
+        // 다른 형식인 경우 Date로 변환 후 포맷팅
+        const date = new Date(birthDateStr);
+        if (isNaN(date.getTime())) {
+          formattedBirthDate = '1970-01-01';
+        } else {
+          formattedBirthDate = date.toISOString().split('T')[0];
+        }
+      }
+    } else {
+      formattedBirthDate = '1970-01-01'; // 기본값
+    }
+
+    return {
+      name: user.name,
+      birthDate: formattedBirthDate,
+      gender: user.gender,
+      address: user.address,
+    };
+  }
+
+  /**
+   * 사용자 정보 업데이트
+   */
+  async updateUserInfo(userId: number, updateUserInfoDto: UpdateUserInfoDto): Promise<UserInfoResponseDto> {
+    // 사용자 존재 여부 확인
+    const user = await this.userRepository.findOne({
+      where: { userId }
+    });
+
+    if (!user) {
+      throw new NotFoundException({
+        statusCode: 404,
+        message: '사용자를 찾을 수 없습니다.',
+      });
+    }
+
+    // 생년월일 문자열을 Date 객체로 변환
+    const birthDate = new Date(updateUserInfoDto.birthDate);
+    if (isNaN(birthDate.getTime())) {
+      throw new HttpException({
+        statusCode: 400,
+        message: '올바르지 않은 생년월일 형식입니다.',
+      }, 400);
+    }
+
+    // 사용자 정보 업데이트 (updatedAt은 @UpdateDateColumn으로 자동 업데이트됨)
+    const updateData: Partial<User> = {
+      name: updateUserInfoDto.name,
+      birthDate: birthDate,
+      gender: updateUserInfoDto.gender,
+    };
+
+    // address가 제공된 경우에만 업데이트
+    if (updateUserInfoDto.address !== undefined) {
+      updateData.address = updateUserInfoDto.address;
+    }
+
+    await this.userRepository.update(userId, updateData);
+
+    // 업데이트된 사용자 정보 반환
+    return this.getUserInfo(userId);
+  }
+
+  /**
+   * 비밀번호 변경
+   */
+  async changePassword(userId: number, changePasswordDto: ChangePasswordDto): Promise<{ message: string }> {
+    const { currentPassword, newPassword } = changePasswordDto;
+
+    // 사용자 존재 여부 확인
+    const user = await this.userRepository.findOne({
+      where: { userId },
+      select: ['userId', 'passwordHash']
+    });
+
+    if (!user) {
+      throw new NotFoundException({
+        statusCode: 404,
+        message: '사용자를 찾을 수 없습니다.',
+      });
+    }
+
+    // 현재 비밀번호 확인
+    const isCurrentPasswordValid = await bcrypt.compare(currentPassword, user.passwordHash);
+    if (!isCurrentPasswordValid) {
+      throw new UnauthorizedException({
+        statusCode: 401,
+        message: '현재 비밀번호가 올바르지 않습니다.',
+      });
+    }
+
+    // 새로운 비밀번호가 현재 비밀번호와 같은지 확인
+    const isSamePassword = await bcrypt.compare(newPassword, user.passwordHash);
+    if (isSamePassword) {
+      throw new HttpException({
+        statusCode: 400,
+        message: '같은 비밀번호입니다. 다른 비밀번호를 입력해주세요.',
+      }, 400);
+    }
+
+    // 새로운 비밀번호 해싱
+    const hashedNewPassword = await bcrypt.hash(newPassword, 10);
+
+    // 비밀번호 업데이트 (updatedAt은 @UpdateDateColumn으로 자동 업데이트됨)
+    await this.userRepository.update(userId, {
+      passwordHash: hashedNewPassword,
+    });
+
+    return {
+      message: '비밀번호가 성공적으로 변경되었습니다.',
+    };
   }
 
 }

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -118,12 +118,7 @@ export class UserService {
         message: '사용자를 찾을 수 없습니다.',
       });
     }
-
-    // 디버깅: birthDate의 타입과 값 확인
-    console.log('birthDate value:', user.birthDate);
-    console.log('birthDate type:', typeof user.birthDate);
-    console.log('birthDate instanceof Date:', user.birthDate instanceof Date);
-
+    
     // birthDate를 안전하게 문자열로 변환
     let formattedBirthDate: string;
     


### PR DESCRIPTION
## 📌 개요
  - 개인정보 수정 로직 구현
  
  ## 🗒️ 작업 내용 요약
  - 주요 변경 사항을 리스트업 해주세요.
    - [O] Dto 비밀번호 변경 요청, 회원 정보 조회, 회원 정보 수정 Dto 구현
    - [O] 비밀번호 변경, 회원 정보 조회, 회원 정보 수정 로직 구현
    - [O] JWT를 통한 회원 식별
    - [O] Swagger JWT 입력 구현

  ## ✅ 테스트 방법
    1. Swagger에서 회원 로그인 후 엑세스 토큰 저장
    2. 엑세스 토큰을 회원 정보 조회 JWT 입력에 넣어 로그인  
    3. 회원에 대한 정보가 나오면 성공
    4. 비밀번호 변경 로직 또한 JWT 입력에 넣어 로그인 후 진행  
  ## 🔗 관련 이슈
  - Closes #10  


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * JWT 기반 인증으로 사용자 엔드포인트 보호.
  * 내 정보 조회/수정 및 비밀번호 변경 기능 추가.
  * 요청/응답 유효성 검증 강화(이름, 생년월일, 성별, 주소, 비밀번호 규칙).
  * Swagger UI에서 Bearer 토큰 입력으로 인증 테스트 가능.
* Documentation
  * Swagger에 Bearer 보안 스키마 등록.
  * 새 엔드포인트의 요청/응답 스키마, 예시, 상태 코드(200/400/401/404) 문서화.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->