### PR TITLE
[fix] 자체 회원가입 중복 socialUid 검사 로직 삭제

### DIFF
--- a/src/user/entities/user.entity.ts
+++ b/src/user/entities/user.entity.ts
@@ -8,7 +8,7 @@ export class User {
   @Column({ type: 'varchar', length: 255, nullable: true, name: 'social_name' })
   socialName: string;
 
-  @Column({ type: 'varchar', length: 255, unique: true, nullable: true, name: 'social_uid' })
+  @Column({ type: 'varchar', length: 255, nullable: true, name: 'social_uid' })
   socialUid: string;
 
   @Column({ type: 'varchar', length: 255, unique: true})

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -48,20 +48,9 @@ export class UserService {
       }, 409);
     }
 
-    // 중복 socialUid 검사
-    if (socialUid) {
-      const existingSocialUser = await this.userRepository.findOne({ where: { socialUid } });
-      if (existingSocialUser) {
-        throw new HttpException({
-          statusCode: 409,
-          message: '이미 사용 중인 소셜 UID입니다.',
-        }, 409);
-      }
-    }
-
     // 비밀번호 해싱
     const hashedPassword = await bcrypt.hash(password, 10);
-    const user = this.userRepository.create({ ...createUserDto, passwordHash: hashedPassword });
+    const user = this.userRepository.create({ ...createUserDto, passwordHash: hashedPassword, socialName: 'SocialUser' });
 
     try {
       return await this.userRepository.save(user);


### PR DESCRIPTION
## 📌 개요
  - 자체 회원가입 중복 socialUid 검사 로직을 삭제했습니다
  
  ## 🗒️ 작업 내용 요약
    - [ ] socialUid 중복 검사 로직 삭제

  
  ## 🤔 변경 이유
  - 중복 socialUid 검사 로직을 자체 회원가입에서 삭제하지 않으면 해당 속성에 계속 null값이 들어가서 두번째 회원가입부터 null값 중복으로 인해 회원가입이 진행되지 않음
  
  ## 🔗 관련 이슈
  - Closes #14 
